### PR TITLE
New SCSI commands, examples and bugfix

### DIFF
--- a/examples/lun_reset.py
+++ b/examples/lun_reset.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# This example shows how to make LUN Reset.
+
+import sys
+
+from scapy.supersocket import StreamSocket
+from scapy_iscsi.iscsi import *
+
+proposed_params = {
+    "InitiatorName": "iqn.2023-01.com.example:initiator",
+    "TargetName": "iqn.2023-01.com.example:target",
+    "SessionType": "Normal",
+    "HeaderDigest": "None",
+    "DataDigest": "None",
+    "ErrorRecoveryLevel": 0,
+    "DefaultTime2Retain": 0,
+    "DefaultTime2Wait": 2,
+    "ImmediateData": "Yes",
+    "FirstBurstLength": 65536,
+    "MaxBurstLength": 262144,
+    "MaxRecvDataSegmentLength": 262144,
+    "MaxOutstandingR2T": 1,
+}
+
+if len(sys.argv) != 2:
+    print("usage: write.py <host>", file=sys.stderr)
+    exit(1)
+
+# установка соединения с удаленным iSCSI таргетом
+s = socket.socket()
+s.connect((sys.argv[1], 3260))
+s = StreamSocket(s, ISCSI)
+
+# отправка запроса на логин
+lirq = ISCSI() / LoginRequest(isid=0xB00B, ds=kv2text(proposed_params))
+lirs = s.sr1(lirq)
+
+negotiated = (text2kv(lirs.ds))
+chunk1 = b"A" * int(negotiated["FirstBurstLength"])
+chunk2 = b"B" * int(negotiated["MaxRecvDataSegmentLength"])
+edtl = len(chunk1) + len(chunk2)
+nr_blocks = int(edtl / 4096)
+
+cdb = CDB() / READ16(xfer_len=nr_blocks)
+
+wrq = ISCSI() / SCSICommand(flags="RF", itt=0x1, cmdsn=lirs.expcmdsn, edtl=edtl, cdb=cdb, lun=0)
+lirs.expcmdsn = lirs.expcmdsn + 2
+
+s.send(wrq)
+wrq = ISCSI() / SCSICommand(flags="RF", itt=0x2, cmdsn=lirs.expcmdsn, edtl=edtl, cdb=cdb, lun=0)
+s.send(wrq)
+
+lirs.expcmdsn = lirs.expcmdsn + 2
+abort = ISCSI(immediate=1) / TMFRequest(function="abort-task", itt=0x2, cmdsn=lirs.expcmdsn,
+                                        rtt=0x5, refcmdsn=lirs.expcmdsn-5, lun=0)
+s.send(abort)
+
+reset = ISCSI(immediate=1) / TMFRequest(function="lun-reset", itt=0x2, cmdsn=lirs.expcmdsn,
+                                        rtt=0xFFFFFFFF, refcmdsn=lirs.expcmdsn, lun=0)
+s.send(reset)
+
+lorq = ISCSI() / LogoutRequest(itt=0x2, cmdsn=lirs.expcmdsn)
+lors = s.sr1(lorq)

--- a/examples/reserve_and_release.py
+++ b/examples/reserve_and_release.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# This example shows how to make SCSI Reserve and Relese commands.
+
+import sys
+from scapy.supersocket import StreamSocket
+from scapy_iscsi.iscsi import *
+
+proposed_params = {
+    "InitiatorName": "iqn.2023-01.com.example:initiator",
+    "TargetName": "iqn.2023-01.com.example:target",
+    "SessionType": "Normal",
+    "HeaderDigest": "None",
+    "DataDigest": "None",
+    "ErrorRecoveryLevel": 0,
+    "DefaultTime2Retain": 0,
+    "DefaultTime2Wait": 2,
+    "ImmediateData": "Yes",
+    "FirstBurstLength": 65536,
+    "MaxBurstLength": 262144,
+    "MaxRecvDataSegmentLength": 262144,
+    "MaxOutstandingR2T": 1,
+}
+
+if len(sys.argv) != 2:
+    print("usage: write.py <host>", file=sys.stderr)
+    exit(1)
+
+s = socket.socket()
+s.connect((sys.argv[1], 3260))
+s = StreamSocket(s, ISCSI)
+
+# Login
+lirq = ISCSI() / LoginRequest(isid=0xB00B, ds=kv2text(proposed_params))
+lirs = s.sr1(lirq)
+
+negotiated = text2kv(lirs.ds)
+
+cdb_reserve = CDB() / RESERVE(lun=0)
+
+wrq = ISCSI() / SCSICommand(flags="F", itt=0x1, cmdsn=lirs.expcmdsn, cdb=cdb_reserve, lun=0)
+reserve = s.sr1(wrq)
+
+cdb_release = CDB() / RELEASE(lun=0)
+
+wrq = ISCSI() / SCSICommand(flags="F", itt=0x1, cmdsn=reserve.expcmdsn, cdb=cdb_release, lun=0)
+release = s.sr1(wrq)
+
+# Logout
+lorq = ISCSI() / LogoutRequest(itt=0x2, cmdsn=release.expcmdsn)
+lors = s.sr1(lorq)

--- a/scapy_iscsi/iscsi.py
+++ b/scapy_iscsi/iscsi.py
@@ -542,5 +542,33 @@ class WRITE16(Packet):
     ]
 
 
+class RESERVE(Packet):
+    name = "SCSI RESERVE"
+    fields_desc = [
+        XBitField("lun", 0x0, 3),
+        XBitField("3rdpty", 0x0, 1),
+        XBitField("3rdpty_device_id", 0x0, 3),
+        XBitField("extent", 0x0, 1),
+        XBitField("reservation_id", 0x0, 8),
+        XBitField("extent_list_len", 0x0, 16),
+        XBitField("control", 0x0, 8),
+    ]
+
+
+class RELEASE(Packet):
+    name = "SCSI RELEASE"
+    fields_desc = [
+        XBitField("lun", 0x0, 3),
+        XBitField("3rdpty", 0x0, 1),
+        XBitField("3rdpty_device_id", 0x0, 3),
+        XBitField("extent", 0x0, 1),
+        XBitField("reservation_id", 0x0, 8),
+        XBitField("reserved", 0x0, 8),
+        XBitField("control", 0x0, 8),
+    ]
+
+
 bind_layers(CDB, READ16, opcode=0x88)
+bind_layers(CDB, RELEASE, opcodes=0x17)
+bind_layers(CDB, RESERVE, opcodes=0x16)
 bind_layers(CDB, WRITE16, opcode=0x8A)

--- a/scapy_iscsi/iscsi.py
+++ b/scapy_iscsi/iscsi.py
@@ -160,7 +160,7 @@ class SCSICommand(Packet):
         BitField("edtl", 0, 32),
         XBitField("cmdsn", 0x0, 32),
         XBitField("expstatsn", 0x0, 32),
-        PacketField("cdb", None, Packet),
+        PadField(PacketField("cdb", None, Packet), 16),
         PacketField("ahs", None, Packet),
         # PacketField("hdr_digest", None, Packet),
         PadField(StrLenField("ds", None, length_from=lambda pkt: pkt.ds_len), 4),


### PR DESCRIPTION
1) Add new commands RESERVE and RELEASE as per SPC-2.
2) Bugfix SCSICommand PadField alignment 
3) Add new example files.