### PR TITLE
Fix param namings to exclude starting with digits

### DIFF
--- a/scapy_iscsi/iscsi.py
+++ b/scapy_iscsi/iscsi.py
@@ -544,10 +544,11 @@ class WRITE16(Packet):
 
 class RESERVE(Packet):
     name = "SCSI RESERVE"
+
     fields_desc = [
         XBitField("lun", 0x0, 3),
-        XBitField("3rdpty", 0x0, 1),
-        XBitField("3rdpty_device_id", 0x0, 3),
+        XBitField("third_party", 0x0, 1),
+        XBitField("dev_id", 0x0, 3),
         XBitField("extent", 0x0, 1),
         XBitField("reservation_id", 0x0, 8),
         XBitField("extent_list_len", 0x0, 16),
@@ -557,10 +558,11 @@ class RESERVE(Packet):
 
 class RELEASE(Packet):
     name = "SCSI RELEASE"
+
     fields_desc = [
         XBitField("lun", 0x0, 3),
-        XBitField("3rdpty", 0x0, 1),
-        XBitField("3rdpty_device_id", 0x0, 3),
+        XBitField("third_party", 0x0, 1),
+        XBitField("dev_id", 0x0, 3),
         XBitField("extent", 0x0, 1),
         XBitField("reservation_id", 0x0, 8),
         XBitField("reserved", 0x0, 8),


### PR DESCRIPTION
According to https://github.com/secdev/scapy/blob/d71014a5adf8fe7144408f78402bd1ca40e9b4a7/scapy/base_classes.py#L342 param names should not start with digits, PR to rename these params