### PR TITLE
Support python 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /venv/
 __pycache__/
+scapy_iscsi.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "scapy-iscsi"
@@ -11,10 +11,7 @@ authors = [
 ]
 description = "iSCSI layer for Scapy"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.6"
 dependencies = [
     "scapy ~=2.5.0",
 ]
-
-[tool.hatch.build.targets.wheel]
-packages = ["scapy_iscsi"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='scapy-iscsi',
+    version='0.1.0',
+    description='iSCSI layer for Scapy',
+    author='Daria Bukharina, Konstantin Shelekhin',
+    author_email='d.bukharina@yadro.com, k.shelekhin@yadro.com',
+    py_modules=['scapy_iscsi'],
+    package_dir={'scapy_iscsi': 'scapy_iscsi'},
+    package_data={},
+    packages=find_packages(),
+    python_requires='>=3.6',
+    install_requires=[
+        'scapy ~=2.5.0',
+    ],
+)


### PR DESCRIPTION
To support python 3.6 (yeah, end-of-support, but really needed):

- setup.py added
- pyproject.toml aligned with it in small details

build-backend was changed to setuptools to have them two consistent